### PR TITLE
source_idのみ返却に変更

### DIFF
--- a/src/sc_system_ai/agents/classify_agent.py
+++ b/src/sc_system_ai/agents/classify_agent.py
@@ -64,7 +64,7 @@ class ClassifyAgent(Agent):
         resp.document_id = self._doc_id_checker()
         return resp
 
-    def _doc_id_checker(self) -> list[str | int] | None:
+    def _doc_id_checker(self) -> list[int] | None:
         """
         ソースIDが存在するか確認する
         """

--- a/src/sc_system_ai/agents/search_school_data_agent.py
+++ b/src/sc_system_ai/agents/search_school_data_agent.py
@@ -42,8 +42,6 @@ class SearchSchoolDataAgent(Agent):
             self.assistant_info += f"### {doc.metadata['title']}\n" + doc.page_content + "\n"
             if "source_id" in doc.metadata:
                 ids.append(doc.metadata["source_id"])
-            else:
-                ids.append(doc.metadata["id"])
         super().set_assistant_info(self.assistant_info)
         return ids
 

--- a/src/sc_system_ai/agents/search_school_data_agent.py
+++ b/src/sc_system_ai/agents/search_school_data_agent.py
@@ -34,7 +34,7 @@ class SearchSchoolDataAgent(Agent):
         )
         self.assistant_info = search_school_data_agent_info
 
-    def _add_search_result(self, message: str) -> list[str | int]:
+    def _add_search_result(self, message: str) -> list[int]:
         word = genarate_search_word(message)
         search = search_school_database_cosmos(word)
         ids = []

--- a/src/sc_system_ai/agents/tools/calling_search_school_data_agent.py
+++ b/src/sc_system_ai/agents/tools/calling_search_school_data_agent.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class CallingSearchSchoolDataAgent(CallingAgent):
     # tool側でidを保持する
-    source_id: set[str | int] = set()
+    source_id: set[int] = set()
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/sc_system_ai/main.py
+++ b/src/sc_system_ai/main.py
@@ -73,7 +73,7 @@ AGENT = Literal["classify", "dummy", "search_school_data", "small_talk"]
 class Response(TypedDict):
     output: str | None
     error: str | None
-    document_id: list[str | int] | None
+    document_id: list[int] | None
 
 class StreamResponse(TypedDict):
     output: str | None

--- a/src/sc_system_ai/template/agent.py
+++ b/src/sc_system_ai/template/agent.py
@@ -102,7 +102,7 @@ class AgentResponse(BaseAgentResponse):
     """Agentのレスポンスの型"""
     chat_history: list[HumanMessage | AIMessage] | None = None
     messages: str | None = None
-    document_id: list[str | int] | None = None
+    document_id: list[int] | None = None
 
 
 class StreamingAgentResponse(BaseAgentResponse):


### PR DESCRIPTION
## 概要

このセクションでは、このPRの目的と概要を簡潔に説明してください。

学校情報検索時にsource_idのみ返却するように変更

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- source_idのみ返却
- AgentResponseのdocument_idをintのみに変更
- Chatクラスinvokeのレスポンスのdocument_id型をintのみに変更

## 関連Issue

このセクションでは、このPRが関連するIssueをリンクしてください。以下のように記述します。

なし
